### PR TITLE
応募方法下部のお問い合わせフォーム URL の誤りを修正

### DIFF
--- a/contests/how-to-apply.html
+++ b/contests/how-to-apply.html
@@ -282,7 +282,7 @@
   </div>
 
   <p>不明点があれば、お問い合わせフォーム（<a target="_blank"
-      href="https://forms.gle/t9ctDcuZZ8cqqFtR">https://forms.gle/t9ctDcuZZ8cqqFtR</a>）にてお知らせください。</p>
+      href="https://forms.gle/t9ctDcuZZ8cqqFtR6">https://forms.gle/t9ctDcuZZ8cqqFtR6</a>）にてお知らせください。</p>
 
   <a href="/contests/index.html" class="link-chevron" style="margin-top: 30px">コンテスト応募要項に戻る</a>
 </body>


### PR DESCRIPTION
## 概要
- 応募方法下部のお問い合わせフォーム URL の誤りを修正
- URL の末尾の1文字が抜けていて、無効な URL になっていた
  - 正: https://forms.gle/t9ctDcuZZ8cqqFtR6
  - 誤: https://forms.gle/t9ctDcuZZ8cqqFtR